### PR TITLE
Compile and install the libsodium 1.0.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,18 @@ RUN docker-php-ext-install -j$(nproc) bcmath \
     && docker-php-ext-install -j$(nproc) intl \
     && docker-php-ext-install -j$(nproc) pgsql \
     && docker-php-ext-install -j$(nproc) pdo_pgsql
+
+# Compile libsodium 1.0.17
+RUN mkdir -p /tmpbuild/libsodium && \
+    cd /tmpbuild/libsodium && \
+    curl -L https://download.libsodium.org/libsodium/releases/libsodium-1.0.17.tar.gz -o libsodium-1.0.17.tar.gz && \
+    tar xfvz libsodium-1.0.17.tar.gz && \
+    cd /tmpbuild/libsodium/libsodium-1.0.17/ && \
+    ./configure && \
+    make && make check && \
+    make install && \
+    mv src/libsodium /usr/local/ && \
+    rm -Rf /tmpbuild/
+
+# Ensure the libsodium extension is up to date
+RUN pecl install libsodium


### PR DESCRIPTION
Our crypto package requires libsodium >=1.0.15, but only 1.0.11 is in the apt repository, so we need to compile our own.