### PR TITLE
Switch to alpine for newer versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,31 @@
-FROM php:7.3-fpm
+FROM alpine:3.9
 
-MAINTAINER woody.gilk@roundingwell.com
+MAINTAINER devops@roundingwell.com
 
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+RUN apk --update --no-cache add \
+    php7 \
+    php7-bcmath \
+    php7-ctype \
+    php7-curl \
+    php7-fpm \
+    php7-intl \
+    php7-iconv \
+    php7-intl \
+    php7-json \
+    php7-mbstring \
+    php7-opcache \
+    php7-openssl \
+    php7-pdo \
+    php7-pdo_pgsql \
+    php7-phar \
+    php7-posix \
+    php7-sodium \
+    php7-xml \
+    php7-zip
 
-COPY conf/intl.ini "$PHP_INI_DIR/conf.d/intl.ini"
-COPY conf/timezone.ini "$PHP_INI_DIR/conf.d/timezone.ini"
+COPY php.ini /etc/php7/conf.d/10-production.ini
+COPY php-fpm.conf /etc/php7/php-fpm.conf
 
-RUN apt-get update && apt-get install -y \
-    libicu-dev \
-    libpq-dev \
-    zlib1g-dev
+EXPOSE 9000
 
-RUN docker-php-ext-install -j$(nproc) bcmath \
-    && docker-php-ext-install -j$(nproc) intl \
-    && docker-php-ext-install -j$(nproc) pgsql \
-    && docker-php-ext-install -j$(nproc) pdo_pgsql
-
-# Compile libsodium 1.0.17
-RUN mkdir -p /tmpbuild/libsodium && \
-    cd /tmpbuild/libsodium && \
-    curl -L https://download.libsodium.org/libsodium/releases/libsodium-1.0.17.tar.gz -o libsodium-1.0.17.tar.gz && \
-    tar xfvz libsodium-1.0.17.tar.gz && \
-    cd /tmpbuild/libsodium/libsodium-1.0.17/ && \
-    ./configure && \
-    make && make check && \
-    make install && \
-    mv src/libsodium /usr/local/ && \
-    rm -Rf /tmpbuild/
-
-# Ensure the libsodium extension is up to date
-RUN pecl install libsodium
+CMD ["php-fpm7", "-F"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# RoundingWell PHP-FPM (prod)
+# RoundingWell PHP-FPM
 
-Docker container for PHP.
+Docker container for PHP-FPM.
 
-Available on Docker Cloud as [`roundingwell/php-fpm`][1].
+<https://hub.docker.com/r/roundingwell/php-fpm>
 
-[1]: https://hub.docker.com/r/roundingwell/php-fpm
+## Build and Test
+
+```bash
+docker build .
+docker run docker run --rm -v $(pwd):/var/www/html $(docker images -q | head -1)
+```

--- a/conf/intl.ini
+++ b/conf/intl.ini
@@ -1,3 +1,0 @@
-intl.default_locale = en_US
-intl.error_level = 0
-intl.use_exceptions = 1

--- a/conf/timezone.ini
+++ b/conf/timezone.ini
@@ -1,1 +1,0 @@
-date.timezone = UTC

--- a/php-fpm.conf
+++ b/php-fpm.conf
@@ -1,0 +1,11 @@
+[www]
+user = nobody
+group = nobody
+listen = [::]:9000
+chroot = /var/www/html
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+catch_workers_output = Yes

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,21 @@
+# https://github.com/php/php-src/blob/master/php.ini-production
+display_errors = Off
+display_startup_errors = Off
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+max_input_time = 60
+register_argc_argv = Off
+request_order = "GP"
+variables_order = "GPCS"
+
+[date]
+date.timezone = UTC
+
+[intl]
+intl.default_locale = en_US
+intl.error_level = 0
+intl.use_exceptions = 1
+
+[session]
+session.auto_start = Off
+session.gc_divisor = 1000
+session.sid_bits_per_character = 5


### PR DESCRIPTION
Problems solved:

- newer version of libsodium
- wider range of extensions available
- faster (and smaller) builds

The only downside is that we are limited to PHP 7.2. 🤷‍♂️ 
